### PR TITLE
[fixbug] 比较版本按字符串比较，返回错误结果。新增`VersionUtil`类将版本按主版本，次版本，修正号进行比较。

### DIFF
--- a/src/main/java/com/easysoftware/common/utils/VersionUtil.java
+++ b/src/main/java/com/easysoftware/common/utils/VersionUtil.java
@@ -1,0 +1,99 @@
+package com.easysoftware.common.utils;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+
+public final class VersionUtil {
+    // Private constructor to prevent instantiation of the utility class
+    private VersionUtil() {
+        // private constructor to hide the implicit public one
+        throw new AssertionError("VersionUtil class cannot be instantiated.");
+    }
+
+    /**
+     * compare two version.
+     * @param version1 version1.
+     * @param version2 version2.
+     * @return int.
+     */
+    public static int compareVersion(String version1, String version2) {
+        PkgVersion ver1 = getVersions(version1);
+        PkgVersion ver2 = getVersions(version2);
+
+        // 比较主版本
+        if (ver1.getMajorVersion() > ver2.getMajorVersion()) {
+            return 1;
+        } else if (ver1.getMajorVersion() < ver2.getMajorVersion()) {
+           return -1;
+        }
+
+        // 比较次版本
+        if (ver1.getMinorVersion() > ver2.getMinorVersion()) {
+            return 1;
+        } else if (ver1.getMinorVersion() < ver2.getMinorVersion()) {
+            return -1;
+        }
+
+        // 比较修正号
+        if (ver1.getRevision() > ver2.getRevision()) {
+            return 1;
+        } else if (ver1.getRevision() < ver2.getRevision()) {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    // rpm的版本为`x.y.z-a`，`x, y, z`分别是主版本，次版本，修正号，`a`是release
+    private static PkgVersion getVersions(String version) {
+        if (StringUtils.isBlank(version)) {
+            return PkgVersion.EMPTY;
+        }
+        String[] splits = version.split("-");
+        if (splits == null || splits.length != 2) {
+            return PkgVersion.EMPTY;
+        }
+        String ver = splits[0];
+        String[] vers = ver.split("\\.");
+
+        if (vers == null || vers.length == 0) {
+            return PkgVersion.EMPTY;
+        }
+
+        PkgVersion pkgVersion = new PkgVersion();
+        for (int i = 0; i < vers.length; i++) {
+            if (i == 0) {
+                pkgVersion.setMajorVersion(Integer.valueOf(vers[0]));
+            } else if (i == 1) {
+                pkgVersion.setMinorVersion(Integer.valueOf(vers[1]));
+            } else if (i == 2) {
+                pkgVersion.setRevision(Integer.valueOf(vers[2]));
+            }
+        }
+        return pkgVersion;
+    }
+
+    @Getter
+    @Setter
+    private static final class PkgVersion {
+        /**
+         * 主版本.
+         */
+        private Integer majorVersion = -1;
+
+
+        private Integer minorVersion = -1;
+        /**
+         * 修正号.
+         */
+        private Integer revision = -1;
+
+        /**
+         * 空对象.
+         */
+        private static final PkgVersion EMPTY = new PkgVersion();
+    }
+}

--- a/src/main/java/com/easysoftware/infrastructure/rpmpackage/gatewayimpl/converter/RPMPackageConverter.java
+++ b/src/main/java/com/easysoftware/infrastructure/rpmpackage/gatewayimpl/converter/RPMPackageConverter.java
@@ -19,6 +19,7 @@ import com.easysoftware.application.rpmpackage.vo.RPMPackageNewestVersionVo;
 import com.easysoftware.application.rpmpackage.vo.PackgeVersionVo;
 import com.easysoftware.common.entity.MessageCode;
 import com.easysoftware.common.utils.SortUtil;
+import com.easysoftware.common.utils.VersionUtil;
 import com.easysoftware.domain.rpmpackage.RPMPackage;
 import com.easysoftware.infrastructure.oepkg.gatewalmpl.dataobject.OepkgDO;
 import com.easysoftware.infrastructure.rpmpackage.gatewayimpl.dataobject.RPMPackageDO;
@@ -220,7 +221,7 @@ public final class RPMPackageConverter {
         }
 
         for (RPMPackageDO rpm : rpmPkgDOs) {
-            if (newestVersion.compareTo(rpm.getVersion()) <= 0) {
+            if (VersionUtil.compareVersion(newestVersion, rpm.getVersion()) <= 0) {
                 newestVersion = rpm.getVersion();
                 os = rpm.getOs();
             }

--- a/src/test/java/com/easysoftware/common/utils/VersionUtilTest.java
+++ b/src/test/java/com/easysoftware/common/utils/VersionUtilTest.java
@@ -1,0 +1,39 @@
+package com.easysoftware.common.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+
+public class VersionUtilTest {
+    @Test
+    void test_version() {
+        String v1 = null;
+        String v2 = "1.0.0-a1";
+        assertEquals(VersionUtil.compareVersion(v1, v2), -1);
+
+        v2 = null;
+        v1 = "1.0.0-a1";
+        assertEquals(VersionUtil.compareVersion(v1, v2), 1);
+
+        v2 = null;
+        v1 = null;
+        assertEquals(VersionUtil.compareVersion(v1, v2), 0);
+
+        v2 = "1.0.0-a1";
+        v1 = "1.0.0-a1";
+        assertEquals(VersionUtil.compareVersion(v1, v2), 0);
+
+        v2 = "1.0.1-a1";
+        v1 = "1.0.0-a1";
+        assertEquals(VersionUtil.compareVersion(v1, v2), -1);
+
+        v1 = "1.0.1-a1";
+        v2 = "1.0.0-a1";
+        assertEquals(VersionUtil.compareVersion(v1, v2), 1);
+
+        v1 = "1.0-a1";
+        v2 = "1.0.0-a1";
+        assertEquals(VersionUtil.compareVersion(v1, v2), -1);
+    }
+}


### PR DESCRIPTION
以版本"7.0.0"与"17.0.0"为例，
如果按照字符串比较，那么"7">"1"，"7.0.0"版本高些。这是错误的。
新增`VersionUtil`类解析版本，按主版本，次版本，修正号进行比较